### PR TITLE
adjust text editor and chat window settings

### DIFF
--- a/create.html
+++ b/create.html
@@ -61,6 +61,7 @@
   <link rel="stylesheet" href="./vendor/codemirror/lint.css">
   <script src="./vendor/codemirror/jshint.min.js"></script>
   <script src="./vendor/codemirror/lint.js"></script>
+  <script src="./vendor/codemirror/scrollpastend.js"></script>
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
   <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
   <script src="https://cdn.rawgit.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>
@@ -172,6 +173,14 @@
       -ms-transform: rotate(90deg);
       -o-transform: rotate(90deg);
       transform: rotate(90deg);
+    }
+    
+    #chatlio-widget .chatlio-widget {
+      right: 0;  
+    }
+    
+    #chatlio-widget .chatlio-widget.closed {
+      width: 200px;
     }
     
   </style>
@@ -455,7 +464,7 @@
     }
     
     // set the text in the editor
-    var editorVal = "setBackdropURL('./images/outerspace.jpg')\n\n\n"
+    var editorVal = "setBackdropURL('./images/outerspace.jpg')\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
     if (getID() != ''){
       editorVal = "// Loading..."
       firebase.database().ref('/code/' + getID()).once('value').then(function(snapshot) {
@@ -547,6 +556,7 @@
         mode:  "javascript",
         value: editorVal,
         lineNumbers: true,
+        lineWrapping: true,
         theme: "eclipse",
         tabSize: 2,
         indentUnit: 2,
@@ -558,7 +568,7 @@
         autofocus: true,
         smartIndent: true,
         foldGutter: true,
-        gutters: ["CodeMirror-lint-markers", "CodeMirror-foldgutter"],
+       // gutters: ["CodeMirror-lint-markers", "CodeMirror-foldgutter"],
         extraKeys: keymap,
         lint: {
           delay: 800, 

--- a/create.html
+++ b/create.html
@@ -13,13 +13,9 @@
 
   <script src="//load.sumome.com/" data-sumo-site-id="44245233c319d8fe9fb7ce8c7ed64db9381aa56477888a10319261f655cfffe2" async="async"></script>
   
-  <script type="text/javascript">
-    window._chatlio = window._chatlio||[];
-    !function(){ var t=document.getElementById("chatlio-widget-embed");if(t&&window.ChatlioReact&&_chatlio.init)return void _chatlio.init(t,ChatlioReact);for(var e=function(t){return function(){_chatlio.push([t].concat(arguments)) }},i=["configure","identify","track","show","hide","isShown","isOnline"],a=0;a<i.length;a++)_chatlio[i[a]]||(_chatlio[i[a]]=e(i[a]));var n=document.createElement("script"),c=document.getElementsByTagName("script")[0];n.id="chatlio-widget-embed",n.src="https://w.chatlio.com/w.chatlio-widget.js",n.async=!0,n.setAttribute("data-embed-version","2.1");
-       n.setAttribute('data-widget-id','1d14bee6-57d0-40e3-4768-8cc33e8abf47');
-       c.parentNode.insertBefore(n,c);
-    }();
-  </script>
+
+
+
 
   <meta charset="utf-8">
   
@@ -176,11 +172,11 @@
     }
     
     #chatlio-widget .chatlio-widget {
-      right: 0;  
+      right: 10px;  
     }
     
-    #chatlio-widget .chatlio-widget.closed {
-      width: 200px;
+    .chatlio-widget.chatlio-title-bar-chip-container.closed {
+      margin-bottom: 5px !important;
     }
     
   </style>
@@ -556,7 +552,7 @@
         mode:  "javascript",
         value: editorVal,
         lineNumbers: true,
-        lineWrapping: true,
+        lineWrapping: false,
         theme: "eclipse",
         tabSize: 2,
         indentUnit: 2,
@@ -568,7 +564,7 @@
         autofocus: true,
         smartIndent: true,
         foldGutter: true,
-       // gutters: ["CodeMirror-lint-markers", "CodeMirror-foldgutter"],
+        gutters: ["CodeMirror-lint-markers", "CodeMirror-foldgutter"],
         extraKeys: keymap,
         lint: {
           delay: 800, 
@@ -691,5 +687,13 @@
     ga('send', 'pageview');
   
   </script>
+<script type="text/javascript">
+    window._chatlio = window._chatlio||[];
+    !function(){ var t=document.getElementById("chatlio-widget-embed");if(t&&window.ChatlioReact&&_chatlio.init)return void _chatlio.init(t,ChatlioReact);for(var e=function(t){return function(){_chatlio.push([t].concat(arguments)) }},i=["configure","identify","track","show","hide","isShown","isOnline"],a=0;a<i.length;a++)_chatlio[i[a]]||(_chatlio[i[a]]=e(i[a]));var n=document.createElement("script"),c=document.getElementsByTagName("script")[0];n.id="chatlio-widget-embed",n.src="https://w.chatlio.com/w.chatlio-widget.js",n.async=!0,n.setAttribute("data-embed-version","2.1");
+       n.setAttribute('data-widget-id','1d14bee6-57d0-40e3-4768-8cc33e8abf47');
+       c.parentNode.insertBefore(n,c);
+    }();
+</script>
+
 </body>
 </html>

--- a/vendor/codemirror/scrollpastend.js
+++ b/vendor/codemirror/scrollpastend.js
@@ -1,0 +1,48 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  CodeMirror.defineOption("scrollPastEnd", true, function(cm, val, old) {
+    if (old && old != CodeMirror.Init) {
+      cm.off("change", onChange);
+      cm.off("refresh", updateBottomMargin);
+      cm.display.lineSpace.parentNode.style.paddingBottom = "";
+      cm.state.scrollPastEndPadding = null;
+    }
+    if (val) {
+      cm.on("change", onChange);
+      cm.on("refresh", updateBottomMargin);
+      updateBottomMargin(cm);
+    }
+  });
+
+  function onChange(cm, change) {
+    if (CodeMirror.changeEnd(change).line == cm.lastLine())
+      updateBottomMargin(cm);
+  }
+
+  function updateBottomMargin(cm) {
+    var padding = "";
+    if (cm.lineCount() > 1) {
+      var totalH = cm.display.scroller.clientHeight - 30,
+          lastLineH = cm.getLineHandle(cm.lastLine()).height;
+      padding = (totalH - lastLineH) + "px";
+    }
+    if (cm.state.scrollPastEndPadding != padding) {
+      cm.state.scrollPastEndPadding = padding;
+      cm.display.lineSpace.parentNode.style.paddingBottom = padding;
+      cm.off("refresh", updateBottomMargin);
+      cm.setSize();
+      cm.on("refresh", updateBottomMargin);
+    }
+  }
+});


### PR DESCRIPTION
I tried a few things:

1) Added scroll past end plugin

2) Added more blank lines to text editor. I tried 60 lines at one point (is there a better way to do this than add 60 "/n"s?) to achieve the goal you were referring to (I believe) but the vertical scrollbar that appears as a result hijacks some of the text editor's limited space when all tabs are open. I still think additional lines might look good, though, and possibly provide users just an iota more direction, so I left it at 25.

3) Another issue the chat window creates besides leaving users wondering what to do when reaching the bottom is confusion over how to horizontally scroll when the line gets too long. I added line wrapping to eliminate this problem altogether.

4) I made the chat window slightly smaller and justified all the way right so it's less in your face but still visible.

5) Are the text editor gutters necessary? I commented them out because I feel like the more space on the editor, the better.