### PR TITLE
allow every to use random intervals

### DIFF
--- a/dist/woof.js
+++ b/dist/woof.js
@@ -720,9 +720,7 @@ function Woof() {
         var lastTimeout = setTimeout(function () {
           theFunction(lastTimeout);
         }, ms);
-
         thisContext._everys.push(lastTimeout);
-        console.log(thisContext._everys);
       };
       theFunction();
     } else {

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -708,23 +708,23 @@ function Woof() {
       }
 
       // create a variable that will be used to store the value of the previous setTimeout()
-      var lastTimeout;
       var theFunction = function theFunction(timeoutValue) {
         var ms = Woof.prototype.unitsToMiliseconds(time(), units);
         func();
         // if the previous setTimeout() value is in the ._everys array, remove it
-        if (thisContext._everys.includes(timeoutValue)) {
+        if (timeoutValue && thisContext._everys.includes(timeoutValue)) {
           thisContext._everys.splice(thisContext._everys.indexOf(timeoutValue), 1);
         }
         // use setTimeout() here instead of setInterval() because the interval has to be able to change
         // pass an anonymous function so we can pass the argument lastTimeout to theFunction()
-        thisContext._everys.push(setTimeout(function () {
+        var lastTimeout = setTimeout(function () {
           theFunction(lastTimeout);
-        }, ms));
-        // set lastTimeout to the value of this most recent setTimeout by pointing to the last element in the ._everys array
-        lastTimeout = thisContext._everys[thisContext._everys.length - 1];
+        }, ms);
+
+        thisContext._everys.push(lastTimeout);
+        console.log(thisContext._everys);
       };
-      theFunction(lastTimeout);
+      theFunction();
     } else {
       var milis = Woof.prototype.unitsToMiliseconds(time, units);
       func();

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -281,7 +281,6 @@ function Woof() {
   };
 
   window.addEventListener("load", function () {
-    // add 100% width and height to containers
     document.documentElement.style.width = "100%";
     document.documentElement.style.height = "100%";
     document.body.style.width = "100%";
@@ -699,12 +698,28 @@ function Woof() {
 
   thisContext._everys = [];
   thisContext.every = function (time, units, func) {
-    var milis = Woof.prototype.unitsToMiliseconds(time, units);
-    if (typeof func != "function" || typeof time != "number") {
+    if (typeof func != "function" || typeof time != "number" && (typeof time === "undefined" ? "undefined" : _typeof(time)) != "object") {
       throw new TypeError("every(time, units, function) requires a number, unit and function input.");
     }
-    func();
-    thisContext._everys.push(setInterval(func, milis));
+
+    // the idea here is that the user would type every([random, 1, 10], 'second', () => {...})
+    // including "random" in the array isn't really necessary other than identifying what you're doing while coding
+    if ((typeof time === "undefined" ? "undefined" : _typeof(time)) == "object") {
+      var init = function init() {
+        var theFunction = function theFunction() {
+          func();
+          var randomTime = Woof.prototype.random(time[1], time[2]);
+          var ms = Woof.prototype.unitsToMiliseconds(randomTime, units);
+          setTimeout(theFunction, ms);
+        };
+        theFunction();
+      };
+      thisContext._everys.push(init());
+    } else {
+      var milis = Woof.prototype.unitsToMiliseconds(time, units);
+      func();
+      thisContext._everys.push(setInterval(func, milis));
+    }
   };
   thisContext.forever = function (func) {
     if (typeof func != "function") {

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -698,18 +698,19 @@ function Woof() {
 
   thisContext._everys = [];
   thisContext.every = function (time, units, func) {
-    if (typeof func != "function" || typeof time != "number" && (typeof time === "undefined" ? "undefined" : _typeof(time)) != "object") {
-      throw new TypeError("every(time, units, function) requires a number, unit and function input.");
+    if (typeof func != "function" || typeof time != "number" && typeof time != "function") {
+      throw new TypeError("every(time, units, function) requires a number/function, time unit and function input.");
     }
-
-    // the idea here is that the user would type every([random, 1, 10], 'second', () => {...})
-    // including "random" in the array isn't really necessary other than identifying what you're doing while coding
-    if ((typeof time === "undefined" ? "undefined" : _typeof(time)) == "object") {
+    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+    if (typeof time == "function") {
+      if (typeof time() != "number") {
+        throw new TypeError("every(time, units, function) requires a time function that returns a number");
+      }
       var init = function init() {
         var theFunction = function theFunction() {
+          var ms = Woof.prototype.unitsToMiliseconds(time(), units);
           func();
-          var randomTime = Woof.prototype.random(time[1], time[2]);
-          var ms = Woof.prototype.unitsToMiliseconds(randomTime, units);
+          // use setTimeout() here instead of setInterval() because the interval has to be able to change
           setTimeout(theFunction, ms);
         };
         theFunction();
@@ -721,6 +722,7 @@ function Woof() {
       thisContext._everys.push(setInterval(func, milis));
     }
   };
+
   thisContext.forever = function (func) {
     if (typeof func != "function") {
       throw new TypeError("forever(function) requires one function input.");

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -697,30 +697,44 @@ function Woof() {
   };
 
   thisContext._everys = [];
+  // thisContext.every = (time, units, func) => {
+  //   if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
+  //   // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+  //   if (typeof time == "function") {
+  //     if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
+  //     // var init = function() {
+  //     //   var theFunction = function() {
+  //     //     var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+  //     //     func();
+  //     //     // use setTimeout() here instead of setInterval() because the interval has to be able to change
+  //     //     thisContext._everys.push(setTimeout(theFunction, ms));
+  //     //   }
+  //     //   theFunction();
+  //     // }
+  //     // thisContext._everys.push(init());
+  //     // init();
+  //     // var theFunction = function() {
+  //     //   var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+  //     //   func();
+  //     //   // use setTimeout() here instead of setInterval() because the interval has to be able to change
+  //     //   thisContext._everys.push(setTimeout(theFunction, ms));
+  //     // }
+  //     // theFunction();
+  //   }
+  //   else {
+  //     var milis = Woof.prototype.unitsToMiliseconds(time, units);
+  //     func();
+  //     thisContext._everys.push(setInterval(func, milis));
+  //   }
+  // };
+
   thisContext.every = function (time, units, func) {
-    if (typeof func != "function" || typeof time != "number" && typeof time != "function") {
-      throw new TypeError("every(time, units, function) requires a number/function, time unit and function input.");
+    var milis = Woof.prototype.unitsToMiliseconds(time, units);
+    if (typeof func != "function" || typeof time != "number") {
+      throw new TypeError("every(time, units, function) requires a number, unit and function input.");
     }
-    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
-    if (typeof time == "function") {
-      if (typeof time() != "number") {
-        throw new TypeError("every(time, units, function) requires a time function that returns a number");
-      }
-      var init = function init() {
-        var theFunction = function theFunction() {
-          var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-          func();
-          // use setTimeout() here instead of setInterval() because the interval has to be able to change
-          setTimeout(theFunction, ms);
-        };
-        theFunction();
-      };
-      thisContext._everys.push(init());
-    } else {
-      var milis = Woof.prototype.unitsToMiliseconds(time, units);
-      func();
-      thisContext._everys.push(setInterval(func, milis));
-    }
+    func();
+    thisContext._everys.push(setInterval(func, milis));
   };
 
   thisContext.forever = function (func) {

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -697,45 +697,47 @@ function Woof() {
   };
 
   thisContext._everys = [];
-  // thisContext.every = (time, units, func) => {
-  //   if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
-  //   // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
-  //   if (typeof time == "function") {
-  //     if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
-  //     // var init = function() {
-  //     //   var theFunction = function() {
-  //     //     var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-  //     //     func();
-  //     //     // use setTimeout() here instead of setInterval() because the interval has to be able to change
-  //     //     thisContext._everys.push(setTimeout(theFunction, ms));
-  //     //   }
-  //     //   theFunction();
-  //     // }
-  //     // thisContext._everys.push(init());
-  //     // init();
-  //     // var theFunction = function() {
-  //     //   var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-  //     //   func();
-  //     //   // use setTimeout() here instead of setInterval() because the interval has to be able to change
-  //     //   thisContext._everys.push(setTimeout(theFunction, ms));
-  //     // }
-  //     // theFunction();
-  //   }
-  //   else {
-  //     var milis = Woof.prototype.unitsToMiliseconds(time, units);
-  //     func();
-  //     thisContext._everys.push(setInterval(func, milis));
-  //   }
-  // };
-
   thisContext.every = function (time, units, func) {
-    var milis = Woof.prototype.unitsToMiliseconds(time, units);
-    if (typeof func != "function" || typeof time != "number") {
-      throw new TypeError("every(time, units, function) requires a number, unit and function input.");
+    if (typeof func != "function" || typeof time != "number" && typeof time != "function") {
+      throw new TypeError("every(time, units, function) requires a number/function, time unit and function input.");
     }
-    func();
-    thisContext._everys.push(setInterval(func, milis));
+    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+    if (typeof time == "function") {
+      if (typeof time() != "number") {
+        throw new TypeError("every(time, units, function) requires a time function that returns a number");
+      }
+
+      // create a variable that will be used to store the value of the previous setTimeout()
+      var lastTimeout;
+      var theFunction = function theFunction(timeoutValue) {
+        var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+        func();
+        // if the previous setTimeout() value is in the ._everys array, remove it
+        if (thisContext._everys.includes(timeoutValue)) {
+          thisContext._everys.splice(thisContext._everys.indexOf(timeoutValue), 1);
+        }
+        // use setTimeout() here instead of setInterval() because the interval has to be able to change
+        // pass an anonymous function so we can pass the argument lastTimeout to theFunction()
+        thisContext._everys.push(setTimeout(function () {
+          theFunction(lastTimeout);
+        }, ms));
+        // set lastTimeout to the value of this most recent setTimeout by pointing to the last element in the ._everys array
+        lastTimeout = thisContext._everys[thisContext._everys.length - 1];
+      };
+      theFunction(lastTimeout);
+    } else {
+      var milis = Woof.prototype.unitsToMiliseconds(time, units);
+      func();
+      thisContext._everys.push(setInterval(func, milis));
+    }
   };
+
+  // thisContext.every = (time, units, func) => {
+  //   var milis = Woof.prototype.unitsToMiliseconds(time, units);
+  //   if (typeof func != "function" || typeof time != "number") { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
+  //   func();
+  //   thisContext._everys.push(setInterval(func, milis));
+  // };
 
   thisContext.forever = function (func) {
     if (typeof func != "function") {

--- a/docs/index.html
+++ b/docs/index.html
@@ -649,6 +649,10 @@
                         description: 'If you want to wait at regular intervals, use every():',
                         tags: "wait every seconds"
                     }, {
+                        code: 'every(() => random(1, 5), "seconds", () => {\n \/* do something here */\n})',
+                        description: 'If you want to wait at changing intervals, use every() with a function instead of a number.',
+                        tags: "wait every seconds random"
+                    }, {
                         url: "./images/68747470733a2f2f692e696d6775722e636f6d2f6a77653133626d2e706e67",
                         code: 'repeat(10, () => {\n  \/* do stuff here */\n})',
                         tags: 'repeat times'

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -435,27 +435,42 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   };
 
   thisContext._everys = [];
+  // thisContext.every = (time, units, func) => {
+  //   if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
+  //   // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+  //   if (typeof time == "function") {
+  //     if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
+  //     // var init = function() {
+  //     //   var theFunction = function() {
+  //     //     var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+  //     //     func();
+  //     //     // use setTimeout() here instead of setInterval() because the interval has to be able to change
+  //     //     thisContext._everys.push(setTimeout(theFunction, ms));
+  //     //   }
+  //     //   theFunction();
+  //     // }
+  //     // thisContext._everys.push(init());
+  //     // init();
+  //     // var theFunction = function() {
+  //     //   var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+  //     //   func();
+  //     //   // use setTimeout() here instead of setInterval() because the interval has to be able to change
+  //     //   thisContext._everys.push(setTimeout(theFunction, ms));
+  //     // }
+  //     // theFunction();
+  //   }
+  //   else {
+  //     var milis = Woof.prototype.unitsToMiliseconds(time, units);
+  //     func();
+  //     thisContext._everys.push(setInterval(func, milis));
+  //   }
+  // };
+  
   thisContext.every = (time, units, func) => {
-    if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
-    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
-    if (typeof time == "function") {
-      if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
-      var init = function() {
-        var theFunction = function() {
-          var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-          func();
-          // use setTimeout() here instead of setInterval() because the interval has to be able to change
-          setTimeout(theFunction, ms);
-        }
-        theFunction();
-      }
-      thisContext._everys.push(init());
-    }
-    else {
-      var milis = Woof.prototype.unitsToMiliseconds(time, units);
-      func();
-      thisContext._everys.push(setInterval(func, milis));
-    }
+    var milis = Woof.prototype.unitsToMiliseconds(time, units);
+    if (typeof func != "function" || typeof time != "number") { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
+    func();
+    thisContext._everys.push(setInterval(func, milis));
   };
   
   thisContext.forever = (func) => {

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -454,9 +454,7 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
         var lastTimeout = setTimeout(function() {
           theFunction(lastTimeout)
         }, ms)
-        
         thisContext._everys.push(lastTimeout);
-        console.log(thisContext._everys)
       }
       theFunction()
     }

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -442,23 +442,23 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
       if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
       
       // create a variable that will be used to store the value of the previous setTimeout()
-      var lastTimeout
       var theFunction = function(timeoutValue) {
         var ms = Woof.prototype.unitsToMiliseconds(time(), units);
         func();
         // if the previous setTimeout() value is in the ._everys array, remove it
-        if (thisContext._everys.includes(timeoutValue)) {
+        if (timeoutValue && thisContext._everys.includes(timeoutValue)) {
           thisContext._everys.splice(thisContext._everys.indexOf(timeoutValue), 1)
         }
         // use setTimeout() here instead of setInterval() because the interval has to be able to change
         // pass an anonymous function so we can pass the argument lastTimeout to theFunction()
-        thisContext._everys.push(setTimeout(function() {
+        var lastTimeout = setTimeout(function() {
           theFunction(lastTimeout)
-        }, ms));
-        // set lastTimeout to the value of this most recent setTimeout by pointing to the last element in the ._everys array
-        lastTimeout = thisContext._everys[thisContext._everys.length - 1]
+        }, ms)
+        
+        thisContext._everys.push(lastTimeout);
+        console.log(thisContext._everys)
       }
-      theFunction(lastTimeout)
+      theFunction()
     }
     else {
       var milis = Woof.prototype.unitsToMiliseconds(time, units);

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -435,43 +435,44 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   };
 
   thisContext._everys = [];
-  // thisContext.every = (time, units, func) => {
-  //   if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
-  //   // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
-  //   if (typeof time == "function") {
-  //     if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
-  //     // var init = function() {
-  //     //   var theFunction = function() {
-  //     //     var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-  //     //     func();
-  //     //     // use setTimeout() here instead of setInterval() because the interval has to be able to change
-  //     //     thisContext._everys.push(setTimeout(theFunction, ms));
-  //     //   }
-  //     //   theFunction();
-  //     // }
-  //     // thisContext._everys.push(init());
-  //     // init();
-  //     // var theFunction = function() {
-  //     //   var ms = Woof.prototype.unitsToMiliseconds(time(), units);
-  //     //   func();
-  //     //   // use setTimeout() here instead of setInterval() because the interval has to be able to change
-  //     //   thisContext._everys.push(setTimeout(theFunction, ms));
-  //     // }
-  //     // theFunction();
-  //   }
-  //   else {
-  //     var milis = Woof.prototype.unitsToMiliseconds(time, units);
-  //     func();
-  //     thisContext._everys.push(setInterval(func, milis));
-  //   }
-  // };
-  
   thisContext.every = (time, units, func) => {
-    var milis = Woof.prototype.unitsToMiliseconds(time, units);
-    if (typeof func != "function" || typeof time != "number") { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
-    func();
-    thisContext._everys.push(setInterval(func, milis));
+    if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
+    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+    if (typeof time == "function") {
+      if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
+      
+      // create a variable that will be used to store the value of the previous setTimeout()
+      var lastTimeout
+      var theFunction = function(timeoutValue) {
+        var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+        func();
+        // if the previous setTimeout() value is in the ._everys array, remove it
+        if (thisContext._everys.includes(timeoutValue)) {
+          thisContext._everys.splice(thisContext._everys.indexOf(timeoutValue), 1)
+        }
+        // use setTimeout() here instead of setInterval() because the interval has to be able to change
+        // pass an anonymous function so we can pass the argument lastTimeout to theFunction()
+        thisContext._everys.push(setTimeout(function() {
+          theFunction(lastTimeout)
+        }, ms));
+        // set lastTimeout to the value of this most recent setTimeout by pointing to the last element in the ._everys array
+        lastTimeout = thisContext._everys[thisContext._everys.length - 1]
+      }
+      theFunction(lastTimeout)
+    }
+    else {
+      var milis = Woof.prototype.unitsToMiliseconds(time, units);
+      func();
+      thisContext._everys.push(setInterval(func, milis));
+    }
   };
+  
+  // thisContext.every = (time, units, func) => {
+  //   var milis = Woof.prototype.unitsToMiliseconds(time, units);
+  //   if (typeof func != "function" || typeof time != "number") { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
+  //   func();
+  //   thisContext._everys.push(setInterval(func, milis));
+  // };
   
   thisContext.forever = (func) => {
     if (typeof func != "function") { throw new TypeError("forever(function) requires one function input."); }

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -436,22 +436,20 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
 
   thisContext._everys = [];
   thisContext.every = (time, units, func) => {
-    if (typeof func != "function" || (typeof time != "number" && typeof time != "object")) { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
-    
-    
-    // the idea here is that the user would type every([random, 1, 10], 'second', () => {...})
-    // including "random" in the array isn't really necessary other than identifying what you're doing while coding
-    if (typeof time == "object") {
+    if (typeof func != "function" || (typeof time != "number" && typeof time != "function")) { throw new TypeError("every(time, units, function) requires a number/function, time unit and function input."); }
+    // if the user inputs something like () => random(1, 10) for the time parameter, re-evaluate the function every time it's run, and update the frequency
+    if (typeof time == "function") {
+      if (typeof time() != "number") { throw new TypeError("every(time, units, function) requires a time function that returns a number")}
       var init = function() {
         var theFunction = function() {
-          func()
-          var randomTime = Woof.prototype.random(time[1], time[2])
-          var ms = Woof.prototype.unitsToMiliseconds(randomTime, units)
-          setTimeout(theFunction, ms)
+          var ms = Woof.prototype.unitsToMiliseconds(time(), units);
+          func();
+          // use setTimeout() here instead of setInterval() because the interval has to be able to change
+          setTimeout(theFunction, ms);
         }
-        theFunction()
+        theFunction();
       }
-      thisContext._everys.push(init())
+      thisContext._everys.push(init());
     }
     else {
       var milis = Woof.prototype.unitsToMiliseconds(time, units);
@@ -459,6 +457,7 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
       thisContext._everys.push(setInterval(func, milis));
     }
   };
+  
   thisContext.forever = (func) => {
     if (typeof func != "function") { throw new TypeError("forever(function) requires one function input."); }
     thisContext.repeatUntil(() => false, func);

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -436,10 +436,28 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
 
   thisContext._everys = [];
   thisContext.every = (time, units, func) => {
-    var milis = Woof.prototype.unitsToMiliseconds(time, units);
-    if (typeof func != "function" || typeof time != "number") { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
-    func();
-    thisContext._everys.push(setInterval(func, milis));
+    if (typeof func != "function" || (typeof time != "number" && typeof time != "object")) { throw new TypeError("every(time, units, function) requires a number, unit and function input."); }
+    
+    
+    // the idea here is that the user would type every([random, 1, 10], 'second', () => {...})
+    // including "random" in the array isn't really necessary other than identifying what you're doing while coding
+    if (typeof time == "object") {
+      var init = function() {
+        var theFunction = function() {
+          func()
+          var randomTime = Woof.prototype.random(time[1], time[2])
+          var ms = Woof.prototype.unitsToMiliseconds(randomTime, units)
+          setTimeout(theFunction, ms)
+        }
+        theFunction()
+      }
+      thisContext._everys.push(init())
+    }
+    else {
+      var milis = Woof.prototype.unitsToMiliseconds(time, units);
+      func();
+      thisContext._everys.push(setInterval(func, milis));
+    }
   };
   thisContext.forever = (func) => {
     if (typeof func != "function") { throw new TypeError("forever(function) requires one function input."); }


### PR DESCRIPTION
I don't see this as being finished, but I want feedback first.

The way I see it, we can't do `every(random(1, 10), 'seconds', () => {...})` because `random()` will just evaluate to a single number, so we need a way to run `random()` within the function itself.

My idea was to allow the `time` parameter passed to `every()` be an array, so you could do something like this: `every([random, 1, 10], 'seconds', () => {...})`

Also, in order for the action to reoccur at random intervals, we can't use `setInterval()`, because that's for regular intervals. So I think we have to repeatedly generate a random number, then use `setTimeout()` with that number, etc. etc.


adding edit: addresses #175  

Another possibility would be to branch this off into a new function called `everyRandom()` -- then you could use it like this: `everyRandom(1, 10, 'seconds', () => {...})`