### PR TITLE
make line angle point toward endpoints

### DIFF
--- a/dist/woof.js
+++ b/dist/woof.js
@@ -1043,15 +1043,9 @@ Woof.prototype.Sprite = function () {
     if (typeof steps != "number") {
       throw new TypeError("move(steps) requires one number input.");
     }
-    // moving lines with this method is tricky, so throw an error (should probably be fixed at some point)
-    if (this.type == "line") {
-      throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead.");
-    }
     // we modify privateX and privateY here before tracking pen so that the pen thinks they changed at the same time
-    else {
-        this.privateX += steps * Math.cos(this.radians());
-        this.privateY += steps * Math.sin(this.radians());
-      }
+    this.privateX += steps * Math.cos(this.radians());
+    this.privateY += steps * Math.sin(this.radians());
     this.project.ready(this.trackPen);
   };
 
@@ -1068,8 +1062,6 @@ Woof.prototype.Sprite = function () {
   };
 
   this.radians = function () {
-    // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
-    if (_this.type == "line") return (_this.angle - 90) * Math.PI / 180;
     return _this.angle * Math.PI / 180;
   };
 
@@ -1567,6 +1559,16 @@ Woof.prototype.Line = function () {
       throw new TypeError("You cannot set line.angle directly. You can only modify line.angle by changing the position of the line's points.");
     }
   });
+
+  // using move() with lines is tricky, so throw an error (should probably be fixed at some point)
+  this.move = function () {
+    throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead.");
+  };
+
+  // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
+  this.radians = function () {
+    return (this.angle - 90) * Math.PI / 180;
+  };
 
   this.render = function (context) {
     context.fillStyle = _this7.color;

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -949,8 +949,10 @@ Woof.prototype.Sprite = function () {
     var rotatedY;
     // If sprite is a line, offsets positioning by half the height as line is drawn from endpoints, not center
     if (this.type == 'line') {
-      rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
-      rotatedY = Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
+      // rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
+      // rotatedY =  Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
+      rotatedX = Math.cos(this.radians()) * (x - this.x - this.width / 2) - Math.sin(this.radians()) * (y - this.y) + this.x;
+      rotatedY = Math.sin(this.radians()) * (x - this.x - this.width / 2) + Math.cos(this.radians()) * (y - this.y) + this.y;
     } else {
       rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y) + this.x;
       rotatedY = Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y) + this.y;
@@ -1511,8 +1513,8 @@ Woof.prototype.Line = function () {
   var _ref10 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
       _ref10$project = _ref10.project,
       project = _ref10$project === undefined ? undefined : _ref10$project,
-      _ref10$width = _ref10.width,
-      width = _ref10$width === undefined ? 1 : _ref10$width,
+      _ref10$thickness = _ref10.thickness,
+      thickness = _ref10$thickness === undefined ? 1 : _ref10$thickness,
       _ref10$x = _ref10.x1,
       x1 = _ref10$x === undefined ? 10 : _ref10$x,
       _ref10$y = _ref10.y1,
@@ -1525,43 +1527,62 @@ Woof.prototype.Line = function () {
   this.x1 = x1;
   this.y1 = y1;
   this.color = color;
-  this.lineWidth = Math.abs(width);
+  this.lineThickness = Math.abs(thickness);
 
-  Object.defineProperty(this, 'width', {
+  Object.defineProperty(this, 'thickness', {
     get: function get() {
-      return this.lineWidth;
+      return this.lineThickness;
     },
     set: function set(value) {
       if (typeof value != "number") {
         throw new TypeError("line.width can only be set to a number.");
       }
-      this.lineWidth = value;
+      this.lineThickness = value;
     }
   });
 
   // Sets height property to hypotenuse of triangle created from x and x1 and y and y1 - this is the length of the 'line'
-  Object.defineProperty(this, 'height', {
+  Object.defineProperty(this, 'length', {
     get: function get() {
       return Math.sqrt(Math.pow(this.x - this.x1, 2) + Math.pow(this.y - this.y1, 2));
     },
     set: function set(value) {
-      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line through moving its points.");
+      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line by moving its endpoints.");
     }
   });
 
   // Rotates rectangle by the angle between x1 and x and y1 and y
   Object.defineProperty(this, 'angle', {
     get: function get() {
-      return Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI;
+      // return Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI;
+      return Math.atan2(this.y - this.y1, this.x - this.x1) * 180 / Math.PI;
     },
     set: function set(value) {
       throw new TypeError("You cannot set line.angle directly. You can only modify line.angle by changing the position of the line's points.");
     }
   });
 
+  Object.defineProperty(this, 'height', {
+    get: function get() {
+      return this.thickness;
+    },
+    set: function set() {
+      throw new TypeError("You cannot set line.height. Please set line.thickness instead.");
+    }
+  });
+
+  Object.defineProperty(this, 'width', {
+    get: function get() {
+      return this.length;
+    },
+    set: function set() {
+      throw new TypeError("You cannot set line.width. You can only modify it by changing the length of your line by moving its endpoints.");
+    }
+  });
+
   this.render = function (context) {
     context.fillStyle = _this7.color;
-    context.fillRect(-_this7.width / 2, -_this7.height, _this7.width, _this7.height);
+    context.fillRect(-_this7.width, -_this7.height / 2, _this7.width, _this7.height);
   };
 };
 

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -1565,7 +1565,7 @@ Woof.prototype.Line = function () {
     throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead.");
   };
 
-  // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
+  // subtract 90 from the angle of a line before calculating radians (undoing the correction in line.angle above)
   this.radians = function () {
     return (this.angle - 90) * Math.PI / 180;
   };

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -627,8 +627,10 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
     var rotatedY;
     // If sprite is a line, offsets positioning by half the height as line is drawn from endpoints, not center
     if (this.type == 'line') {
-      rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
-      rotatedY =  Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
+      // rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
+      // rotatedY =  Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
+      rotatedX = Math.cos(this.radians()) * (x - this.x - this.width / 2) - Math.sin(this.radians()) * (y - this.y) + this.x;
+      rotatedY =  Math.sin(this.radians()) * (x - this.x - this.width / 2) + Math.cos(this.radians()) * (y - this.y) + this.y;
     }
     else {
       rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y) + this.x;
@@ -1063,47 +1065,66 @@ Woof.prototype.Rectangle = function({project = undefined, height = 10, width = 1
 };
 
 // Creates a 'line' sprite by rendering a rotated rectangle
-Woof.prototype.Line = function({project = undefined, width = 1, x1 = 10, y1 = 10, color = "black"} = {}) {
-  this.type = "line"
+Woof.prototype.Line = function({project = undefined, thickness = 1, x1 = 10, y1 = 10, color = "black"} = {}) {
+  this.type = "line";
   Woof.prototype.Sprite.call(this, arguments[0]);
   this.x1 = x1;
   this.y1 = y1;
   this.color = color;
-  this.lineWidth = Math.abs(width);
+  this.lineThickness = Math.abs(thickness);
   
-  Object.defineProperty(this, 'width', {
+  Object.defineProperty(this, 'thickness', {
     get: function() {
-      return this.lineWidth;
+      return this.lineThickness;
     },
     set: function(value) {
       if (typeof value != "number") { throw new TypeError("line.width can only be set to a number."); }
-      this.lineWidth = value;
+      this.lineThickness = value;
     }
   });
   
   // Sets height property to hypotenuse of triangle created from x and x1 and y and y1 - this is the length of the 'line'
-  Object.defineProperty(this, 'height', {
+  Object.defineProperty(this, 'length', {
     get: function() {
       return Math.sqrt((Math.pow((this.x - this.x1), 2)) + (Math.pow((this.y - this.y1), 2)));
     },
     set: function(value) {
-      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line through moving its points."); 
+      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line by moving its endpoints."); 
     }
   }); 
   
   // Rotates rectangle by the angle between x1 and x and y1 and y
   Object.defineProperty(this, 'angle', {
     get: function() {
-      return Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI;
+      // return Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI;
+      return Math.atan2(this.y - this.y1, this.x - this.x1) * 180 / Math.PI;
     },
     set: function(value) {
       throw new TypeError("You cannot set line.angle directly. You can only modify line.angle by changing the position of the line's points."); 
     }
-  }); 
+  });
+  
+  Object.defineProperty(this, 'height', {
+    get: function() {
+      return this.thickness;
+    },
+    set: function() {
+      throw new TypeError("You cannot set line.height. Please set line.thickness instead.");
+    }
+  });
+  
+  Object.defineProperty(this, 'width', {
+    get: function() {
+      return this.length;
+    },
+    set: function() {
+      throw new TypeError("You cannot set line.width. You can only modify it by changing the length of your line by moving its endpoints.")
+    }
+  })
   
   this.render = (context) => {
     context.fillStyle=this.color;
-    context.fillRect(-this.width / 2, -this.height, this.width, this.height);
+    context.fillRect(-this.width, -this.height / 2, this.width, this.height);
   };
 };
 

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -716,13 +716,9 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   
   this.move = function(steps = 1){
     if (typeof steps != "number") { throw new TypeError("move(steps) requires one number input."); }
-    // moving lines with this method is tricky, so throw an error (should probably be fixed at some point)
-    if (this.type == "line") { throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead."); }
     // we modify privateX and privateY here before tracking pen so that the pen thinks they changed at the same time
-    else {
-      this.privateX += steps * Math.cos(this.radians());
-      this.privateY += steps * Math.sin(this.radians());
-    }
+    this.privateX += steps * Math.cos(this.radians());
+    this.privateY += steps * Math.sin(this.radians());
     this.project.ready(this.trackPen);
   };
   
@@ -739,9 +735,6 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   };
   
   this.radians = () => {
-    // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
-    if (this.type == "line")
-      return (this.angle - 90) * Math.PI / 180;
     return this.angle * Math.PI / 180;
   };
   
@@ -1108,6 +1101,14 @@ Woof.prototype.Line = function({project = undefined, width = 1, x1 = 10, y1 = 10
       throw new TypeError("You cannot set line.angle directly. You can only modify line.angle by changing the position of the line's points."); 
     }
   }); 
+  
+  // using move() with lines is tricky, so throw an error (should probably be fixed at some point)
+  this.move = function() { throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead."); };
+  
+  // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
+  this.radians = function() {
+    return (this.angle - 90) * Math.PI / 180;
+  };
   
   this.render = (context) => {
     context.fillStyle=this.color;

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -1105,7 +1105,7 @@ Woof.prototype.Line = function({project = undefined, width = 1, x1 = 10, y1 = 10
   // using move() with lines is tricky, so throw an error (should probably be fixed at some point)
   this.move = function() { throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead."); };
   
-  // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
+  // subtract 90 from the angle of a line before calculating radians (undoing the correction in line.angle above)
   this.radians = function() {
     return (this.angle - 90) * Math.PI / 180;
   };

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -627,10 +627,8 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
     var rotatedY;
     // If sprite is a line, offsets positioning by half the height as line is drawn from endpoints, not center
     if (this.type == 'line') {
-      // rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
-      // rotatedY =  Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
-      rotatedX = Math.cos(this.radians()) * (x - this.x - this.width / 2) - Math.sin(this.radians()) * (y - this.y) + this.x;
-      rotatedY =  Math.sin(this.radians()) * (x - this.x - this.width / 2) + Math.cos(this.radians()) * (y - this.y) + this.y;
+      rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y + this.height / 2) + this.x;
+      rotatedY =  Math.sin(this.radians()) * (x - this.x) + Math.cos(this.radians()) * (y - this.y + this.height / 2) + this.y;
     }
     else {
       rotatedX = Math.cos(this.radians()) * (x - this.x) - Math.sin(this.radians()) * (y - this.y) + this.x;
@@ -718,9 +716,13 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   
   this.move = function(steps = 1){
     if (typeof steps != "number") { throw new TypeError("move(steps) requires one number input."); }
+    // moving lines with this method is tricky, so throw an error (should probably be fixed at some point)
+    if (this.type == "line") { throw new TypeError("You cannot move lines with move() unfortunately! Change the x, y, x1, and y1 values instead."); }
     // we modify privateX and privateY here before tracking pen so that the pen thinks they changed at the same time
-    this.privateX += steps * Math.cos(this.radians());
-    this.privateY += steps * Math.sin(this.radians());
+    else {
+      this.privateX += steps * Math.cos(this.radians());
+      this.privateY += steps * Math.sin(this.radians());
+    }
     this.project.ready(this.trackPen);
   };
   
@@ -737,6 +739,9 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   };
   
   this.radians = () => {
+    // subtract 90 from the angle of a line before calculating radians (undoing the correction in the Line() constructor)
+    if (this.type == "line")
+      return (this.angle - 90) * Math.PI / 180;
     return this.angle * Math.PI / 180;
   };
   
@@ -1065,66 +1070,48 @@ Woof.prototype.Rectangle = function({project = undefined, height = 10, width = 1
 };
 
 // Creates a 'line' sprite by rendering a rotated rectangle
-Woof.prototype.Line = function({project = undefined, thickness = 1, x1 = 10, y1 = 10, color = "black"} = {}) {
-  this.type = "line";
+Woof.prototype.Line = function({project = undefined, width = 1, x1 = 10, y1 = 10, color = "black"} = {}) {
+  this.type = "line"
   Woof.prototype.Sprite.call(this, arguments[0]);
   this.x1 = x1;
   this.y1 = y1;
   this.color = color;
-  this.lineThickness = Math.abs(thickness);
+  this.lineWidth = Math.abs(width);
   
-  Object.defineProperty(this, 'thickness', {
+  Object.defineProperty(this, 'width', {
     get: function() {
-      return this.lineThickness;
+      return this.lineWidth;
     },
     set: function(value) {
       if (typeof value != "number") { throw new TypeError("line.width can only be set to a number."); }
-      this.lineThickness = value;
+      this.lineWidth = value;
     }
   });
   
   // Sets height property to hypotenuse of triangle created from x and x1 and y and y1 - this is the length of the 'line'
-  Object.defineProperty(this, 'length', {
+  Object.defineProperty(this, 'height', {
     get: function() {
       return Math.sqrt((Math.pow((this.x - this.x1), 2)) + (Math.pow((this.y - this.y1), 2)));
     },
     set: function(value) {
-      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line by moving its endpoints."); 
+      throw new TypeError("You cannot set line.height directly. You can only modify line.height by changing the length of your line through moving its points."); 
     }
   }); 
   
   // Rotates rectangle by the angle between x1 and x and y1 and y
+  // Add 90 to the angle because "height" and "width" are essentially reversed in comparison to a rectangle sprite
   Object.defineProperty(this, 'angle', {
     get: function() {
-      // return Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI;
-      return Math.atan2(this.y - this.y1, this.x - this.x1) * 180 / Math.PI;
+      return (Math.atan2(-this.x1 + this.x, this.y1 - this.y) * 180 / Math.PI) + 90;
     },
     set: function(value) {
       throw new TypeError("You cannot set line.angle directly. You can only modify line.angle by changing the position of the line's points."); 
     }
-  });
-  
-  Object.defineProperty(this, 'height', {
-    get: function() {
-      return this.thickness;
-    },
-    set: function() {
-      throw new TypeError("You cannot set line.height. Please set line.thickness instead.");
-    }
-  });
-  
-  Object.defineProperty(this, 'width', {
-    get: function() {
-      return this.length;
-    },
-    set: function() {
-      throw new TypeError("You cannot set line.width. You can only modify it by changing the length of your line by moving its endpoints.")
-    }
-  })
+  }); 
   
   this.render = (context) => {
     context.fillStyle=this.color;
-    context.fillRect(-this.width, -this.height / 2, this.width, this.height);
+    context.fillRect(-this.width / 2, -this.height, this.width, this.height);
   };
 };
 


### PR DESCRIPTION
Addresses #395 

@madduccino @stevekrouse can you take a look?

I swapped "width" and "height" for "length" and "thickness", since they seem to be more intuitive when dealing with a line. I'm not crazy about "thickness" but I couldn't think of a better alternative. Any thoughts?

That being said, I actually kept "width" and "height" as properties of a line object because those properties are used for rendering and for the collider. I figured it was better this way than putting more if-statements in the renderer and collider. I simply pointed `line.width` to `line.length` and `line.height` to `line.thickness` with getters, and made the setters return errors.

I still need to edit the comments and update the documentation, but I wanted to test it out here first (cloud9 is being a pain...)