### PR TITLE
fixed spaces in project names bug

### DIFF
--- a/create.html
+++ b/create.html
@@ -699,7 +699,7 @@
           }.bind(this), 10)
 
 
-          this.projectNameInputValue = newName.replace(" ", "-")
+          this.projectNameInputValue = newName.replace(/ /g, "-")
           this.projectNameInputValue = this.projectNameInputValue.replace(/\.|#|\$|\/|\[|\]/g, "")
         },
         saveName : function() {


### PR DESCRIPTION
I noticed that the project naming had a bug that allowed for spaces in project names. If you copied and pasted a string with several spaces it would only replace the first space. This fixes that issue by using a method that replaces all spaces in the string. 