### PR TITLE
Corrected Misspelling of Lilypad Sprite Url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -729,7 +729,7 @@
                             
                             {
                                 url: "./images/fly-lilypad.png",
-                                code: 'var lilypad = new Image({\n  url: "./docs/images/fly-lilipad.png",\n  width: 100, \n  height: 85,\n})',
+                                code: 'var lilypad = new Image({\n  url: "./docs/images/fly-lilypad.png",\n  width: 100, \n  height: 85,\n})',
                                 tags: "lilypad sprite",
                             },
                             


### PR DESCRIPTION
I changed the url for the lilypad sprite from "./docs/images/fly-lilipad.png" to "./docs/images/fly-lilypad.png".

Closes #506 