### PR TITLE
fix bug in error highlighting

### DIFF
--- a/create.html
+++ b/create.html
@@ -1523,8 +1523,7 @@
     function tryRunningCode() {
       app.code = editor.getValue()
       app.error = undefined
-      var count = editor.lineCount(), i;
-      for (i = 0; i < count; i++) {
+      for (var i = 0; i < editor.lineCount(); i++) {
         editor.removeLineClass(i, 'text', 'error-highlight');
       }
       try {

--- a/create.html
+++ b/create.html
@@ -1523,8 +1523,9 @@
     function tryRunningCode() {
       app.code = editor.getValue()
       app.error = undefined
-      if (app.errorLineNumber) {
-        editor.removeLineClass(app.errorLineNumber - 1, 'text', 'error-highlight');
+      var count = editor.lineCount(), i;
+      for (i = 0; i < count; i++) {
+        editor.removeLineClass(i, 'text', 'error-highlight');
       }
       try {
         var result = Babel.transform(editor.getValue(), {


### PR DESCRIPTION
There is a bug in removing error highlight under certain circumstances. Here's an example:

Error created on line 4:

![screenshot 2017-10-21 at 9 06 51 pm](https://user-images.githubusercontent.com/2099441/31857144-d27d2272-b6a3-11e7-9dd9-8f758bab3fba.png)

New code added which creates another error on line 3:

![screenshot 2017-10-21 at 9 07 53 pm](https://user-images.githubusercontent.com/2099441/31857150-0065e5a2-b6a4-11e7-909b-b06276b5255d.png)

Error on line 3 is fixed which resolves the original error that is now on line 6. As a result, `errorLineNumber` stays at 3 and the highlight on line 6 is not removed.

![screenshot 2017-10-21 at 9 25 29 pm](https://user-images.githubusercontent.com/2099441/31857205-68792d3c-b6a6-11e7-8b63-70c8c99fc670.png)


I resolved this by removing the highlight from ALL lines each time `tryRunningCode` is run.
