### PR TITLE
Polygon event listener

### DIFF
--- a/dist/woof.js
+++ b/dist/woof.js
@@ -1913,7 +1913,7 @@ Woof.prototype.Repeat = function (times, func, after) {
   var _this11 = this;
 
   this.func = func;
-  this.times = times;
+  this.times = Math.floor(times);
   this.done = false;
 
   this.next = function () {

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -852,6 +852,10 @@ function Woof() {
     thisContext._renderSprites();
   };
   thisContext.ready(thisContext._render);
+
+  thisContext.collider = function () {
+    return new SAT.Polygon(new SAT.Vector(), [new SAT.Vector(-thisContext.width / 2, thisContext.height / 2), new SAT.Vector(-thisContext.width / 2, -thisContext.height / 2), new SAT.Vector(thisContext.width / 2, -thisContext.height / 2), new SAT.Vector(thisContext.width / 2, thisContext.height / 2)]);
+  };
 };
 
 Woof.prototype.Sprite = function () {
@@ -1192,36 +1196,12 @@ Woof.prototype.Sprite = function () {
         bottom = _ref6.bottom;
 
 
-    var collider = _this.collider();
-
-    // If collider is a circle, make sure it is inside canvas
-    if (collider.constructor.name == "Circle") {
-      return !(left > collider.pos.x + collider.r || right < collider.pos.x - collider.r || top < collider.pos.y - collider.r || bottom > collider.pos.y + collider.r);
+    if (_this.collider().constructor.name == "Circle") {
+      console.log(SAT.testPolygonCircle(_this.project.collider(), _this.collider(), new SAT.Response()));
+      return SAT.testPolygonCircle(_this.project.collider(), _this.collider(), new SAT.Response());
     }
-
-    // Otherwise, collider is a polygon. Find out if it's inside canvas by finding min and max points
-    // Create array for x coordinates of collider polygon
-    var xs = [];
-    for (var i = 0; i < collider.calcPoints.length; i++) {
-      xs.push(collider.calcPoints[i].x);
-    }
-    // Create array for y coordinates of collider polygon
-    var ys = [];
-    for (var i = 0; i < collider.calcPoints.length; i++) {
-      ys.push(collider.calcPoints[i].y);
-    }
-    // Sort array to find max/min x coordinates
-    var sortedX = xs.sort(function (a, b) {
-      return a - b;
-    });
-    // Sort array to find max/min y coordinates
-    var sortedY = ys.sort(function (a, b) {
-      return a - b;
-    });
-
-    var maxX = sortedX.length - 1;
-    var maxY = sortedY.length - 1;
-    return !(left > sortedX[maxX] + collider.pos.x || top < sortedY[0] + collider.pos.y || right < sortedX[0] + collider.pos.x || bottom > sortedY[maxY] + collider.pos.y);
+    console.log(SAT.testPolygonPolygon(_this.project.collider(), _this.collider(), new SAT.Response()));
+    return SAT.testPolygonPolygon(_this.project.collider(), _this.collider(), new SAT.Response());
   };
 
   this.over = function (x, y) {

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -1197,10 +1197,8 @@ Woof.prototype.Sprite = function () {
 
 
     if (_this.collider().constructor.name == "Circle") {
-      console.log(SAT.testPolygonCircle(_this.project.collider(), _this.collider(), new SAT.Response()));
       return SAT.testPolygonCircle(_this.project.collider(), _this.collider(), new SAT.Response());
     }
-    console.log(SAT.testPolygonPolygon(_this.project.collider(), _this.collider(), new SAT.Response()));
     return SAT.testPolygonPolygon(_this.project.collider(), _this.collider(), new SAT.Response());
   };
 

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -489,6 +489,12 @@ function Woof() {
   // the y-axis works counter-intuitively, decreasing as you move up, and increasing as you move down
   // translateToCenter maps coordinates from the HTML canvas to the Scratch-world where (0,0) is in the center of the screen  
   thisContext.translateToCenter = function (x, y) {
+    // If sprite is a polygon, do not translate to center
+    if (thisContext.sprites.length > 0) {
+      if (thisContext.sprites[0].type == "polygon") {
+        return [x, y];
+      }
+    }
     return [x - thisContext.width / 2 + thisContext.cameraX - thisContext._spriteCanvas.offsetLeft, thisContext.height / 2 - y + thisContext.cameraY + thisContext._spriteCanvas.offsetTop];
   };
   // translateToCanvas (the opposite of translateToCenter) maps coordinates from the Scratch-world to the HTML canvas world with (0,0) in the top-left  

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -489,12 +489,6 @@ function Woof() {
   // the y-axis works counter-intuitively, decreasing as you move up, and increasing as you move down
   // translateToCenter maps coordinates from the HTML canvas to the Scratch-world where (0,0) is in the center of the screen  
   thisContext.translateToCenter = function (x, y) {
-    // If sprite is a polygon, do not translate to center
-    if (thisContext.sprites.length > 0) {
-      if (thisContext.sprites[0].type == "polygon") {
-        return [x, y];
-      }
-    }
     return [x - thisContext.width / 2 + thisContext.cameraX - thisContext._spriteCanvas.offsetLeft, thisContext.height / 2 - y + thisContext.cameraY + thisContext._spriteCanvas.offsetTop];
   };
   // translateToCanvas (the opposite of translateToCenter) maps coordinates from the Scratch-world to the HTML canvas world with (0,0) in the top-left  

--- a/dist/woof.js
+++ b/dist/woof.js
@@ -371,7 +371,7 @@ function Woof() {
   });
 
   thisContext.bounds = function () {
-    return { left: thisContext.minX, right: thisContext.maxX, bottom: thisContext.minYm, top: thisContext.maxY };
+    return { left: thisContext.minX, right: thisContext.maxX, bottom: thisContext.minY, top: thisContext.maxY };
   };
 
   thisContext.randomX = function () {
@@ -979,28 +979,50 @@ Woof.prototype.Sprite = function () {
     return new SAT.Vector(v.x - pos.x, v.y - pos.y);
   };
 
-  // Creates collider polygon from vector vertices
+  // Creates collider from vector vertices
   this.collider = function () {
-    var pos = this.rotatedVector(this.x - this.width / 2, this.y - this.height / 2);
-    var v1 = new SAT.Vector(0, 0);
-    var v2 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y - this.height / 2));
-    var v3 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y + this.height / 2));
-    var v4 = this.translatedVector(pos, this.rotatedVector(this.x - this.width / 2, this.y + this.height / 2));
-
-    return new SAT.Polygon(pos, [v1, v2, v3, v4]);
+    // If sprite is a circle, create circle collider
+    if (this.type == "circle") {
+      return new SAT.Circle(new SAT.Vector(this.x, this.y), this.radius);
+    }
+    // If sprite is a polygon, create polygon collider
+    else if (this.type == "polygon") {
+        var pos = this.rotatedVector(this.x, this.y);
+        var vs = [new SAT.Vector(this.length * 1, this.length * 0)];
+        for (var i = 1; i < this.sides; i++) {
+          vs.push(new SAT.Vector(this.length * Math.cos(i * (2 * Math.PI / this.sides)), this.length * Math.sin(i * (2 * Math.PI / this.sides))));
+        }
+        return new SAT.Polygon(pos, vs).rotate(this.radians());
+      }
+      // Otherwise, create 4-sided collider around sprite
+      else {
+          var pos = this.rotatedVector(this.x - this.width / 2, this.y - this.height / 2);
+          var v1 = new SAT.Vector(0, 0);
+          var v2 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y - this.height / 2));
+          var v3 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y + this.height / 2));
+          var v4 = this.translatedVector(pos, this.rotatedVector(this.x - this.width / 2, this.y + this.height / 2));
+          return new SAT.Polygon(pos, [v1, v2, v3, v4]);
+        }
   };
 
-  // for debugging purposes, this function displays the collider on the screen                                     
+  // for debugging purposes, this function displays the collider on the screen according to type of sprite
   this._renderCollider = function (context) {
     var collider = this.collider();
 
     context.save();
     context.beginPath();
-    context.moveTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[0].x + collider.pos.x, collider.calcPoints[0].y + collider.pos.y)));
-    context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[1].x + collider.pos.x, collider.calcPoints[1].y + collider.pos.y)));
-    context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[2].x + collider.pos.x, collider.calcPoints[2].y + collider.pos.y)));
-    context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[3].x + collider.pos.x, collider.calcPoints[3].y + collider.pos.y)));
-    context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[0].x + collider.pos.x, collider.calcPoints[0].y + collider.pos.y)));
+
+    if (collider.constructor.name == "Circle") {
+      context.arc.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.pos.x, collider.pos.y)).concat([collider.r, 0, 2 * Math.PI]));
+    } else {
+      context.moveTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[0].x + collider.pos.x, collider.calcPoints[0].y + collider.pos.y)));
+
+      for (var i = 1; i < this.collider().edges.length; i++) {
+        context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[i].x + collider.pos.x, collider.calcPoints[i].y + collider.pos.y)));
+      }
+      context.lineTo.apply(context, _toConsumableArray(this.project.translateToCanvas(collider.calcPoints[0].x + collider.pos.x, collider.calcPoints[0].y + collider.pos.y)));
+    }
+
     context.strokeStyle = "green";
     context.lineWidth = 4;
     context.stroke();
@@ -1169,8 +1191,37 @@ Woof.prototype.Sprite = function () {
         top = _ref6.top,
         bottom = _ref6.bottom;
 
-    var r1 = _this.bounds();
-    return !(left > r1.right || right < r1.left || top < r1.bottom || bottom > r1.top);
+
+    var collider = _this.collider();
+
+    // If collider is a circle, make sure it is inside canvas
+    if (collider.constructor.name == "Circle") {
+      return !(left > collider.pos.x + collider.r || right < collider.pos.x - collider.r || top < collider.pos.y - collider.r || bottom > collider.pos.y + collider.r);
+    }
+
+    // Otherwise, collider is a polygon. Find out if it's inside canvas by finding min and max points
+    // Create array for x coordinates of collider polygon
+    var xs = [];
+    for (var i = 0; i < collider.calcPoints.length; i++) {
+      xs.push(collider.calcPoints[i].x);
+    }
+    // Create array for y coordinates of collider polygon
+    var ys = [];
+    for (var i = 0; i < collider.calcPoints.length; i++) {
+      ys.push(collider.calcPoints[i].y);
+    }
+    // Sort array to find max/min x coordinates
+    var sortedX = xs.sort(function (a, b) {
+      return a - b;
+    });
+    // Sort array to find max/min y coordinates
+    var sortedY = ys.sort(function (a, b) {
+      return a - b;
+    });
+
+    var maxX = sortedX.length - 1;
+    var maxY = sortedY.length - 1;
+    return !(left > sortedX[maxX] + collider.pos.x || top < sortedY[0] + collider.pos.y || right < sortedX[0] + collider.pos.x || bottom > sortedY[maxY] + collider.pos.y);
   };
 
   this.over = function (x, y) {
@@ -1181,12 +1232,21 @@ Woof.prototype.Sprite = function () {
       return false;
     }
 
-    var r1 = _this.bounds();
-    var belowTop = y <= r1.top;
-    var aboveBottom = y >= r1.bottom;
-    var rightLeft = x >= r1.left;
-    var leftRight = x <= r1.right;
-    return belowTop && aboveBottom && rightLeft && leftRight;
+    var collider = _this.collider();
+
+    // If shape is an oval, find point in oval. SAT.js does not include this in library. 
+    // This is more exact than a collider polygon drawn around it.
+    if (_this.type == "oval") {
+      return Math.pow(x - _this.x, 2) / Math.pow(_this.width / 2, 2) + Math.pow(y - _this.y, 2) / Math.pow(_this.height / 2, 2) <= 1;
+    }
+    // If collider is a circle, find point in circle
+    else if (collider.constructor.name == "Circle") {
+        return SAT.pointInCircle(new SAT.Vector(x, y), _this.collider());
+      }
+      // Otherwise look for point in polygon
+      else {
+          return SAT.pointInPolygon(new SAT.Vector(x, y), _this.collider());
+        }
   };
 
   Object.defineProperty(this, 'mouseOver', {
@@ -1614,16 +1674,6 @@ Woof.prototype.Polygon = function () {
     }
   });
 
-  this.collider = function () {
-    var pos = this.rotatedVector(this.x - this.length, this.y - this.length);
-    var v1 = new SAT.Vector(0, 0);
-    var v2 = this.translatedVector(pos, this.rotatedVector(this.x + this.length, this.y - this.length));
-    var v3 = this.translatedVector(pos, this.rotatedVector(this.x + this.length, this.y + this.length));
-    var v4 = this.translatedVector(pos, this.rotatedVector(this.x - this.length, this.y + this.length));
-
-    return new SAT.Polygon(pos, [v1, v2, v3, v4]);
-  };
-
   this.render = function (context) {
     context.fillStyle = _this8.color;
     context.beginPath();
@@ -1794,10 +1844,11 @@ Woof.prototype.Sound = function () {
       low: 0.5,
       normal: 1
     }
+  };
 
-    // Convert given value to corresponding audio object value
-    // Throw error if given value not found in allowed values
-  };var soundVolumeToAudioVolume = function soundVolumeToAudioVolume(val) {
+  // Convert given value to corresponding audio object value
+  // Throw error if given value not found in allowed values
+  var soundVolumeToAudioVolume = function soundVolumeToAudioVolume(val) {
     if (typeof val == "number") {
       if (val >= 0 && val <= 1) {
         return val;

--- a/docs/index.html
+++ b/docs/index.html
@@ -706,7 +706,7 @@
                             
                             {
                                 url: "./images/boss-ship.png",
-                                code: 'var bossShip2 = new Image({\n  url: "./docs/boss-ship/explosion.png",\n  width: 100, \n  height: 100,\n})',
+                                code: 'var bossShip2 = new Image({\n  url: "./docs/images/boss-ship.png",\n  width: 100, \n  height: 100,\n})',
                                 tags: "ship sprite",
                             },
                             

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -855,11 +855,9 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   this.overlap = ({left, right, top, bottom}) => {
   
     if (this.collider().constructor.name == "Circle") {
-      console.log(SAT.testPolygonCircle(this.project.collider(), this.collider(), new SAT.Response()))
       return SAT.testPolygonCircle(this.project.collider(), this.collider(),  new SAT.Response())
     }
-        console.log(SAT.testPolygonPolygon(this.project.collider(), this.collider(), new SAT.Response()))
-      return SAT.testPolygonPolygon(this.project.collider(), this.collider(), new SAT.Response())
+    return SAT.testPolygonPolygon(this.project.collider(), this.collider(), new SAT.Response())
     
   }
   

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -1393,7 +1393,7 @@ Woof.prototype.customSprite = function(subClass) {
 
 Woof.prototype.Repeat = function(times, func, after) {
   this.func = func;
-  this.times = times;
+  this.times = Math.floor(times);
   this.done = false;
   
   this.next = () => {

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -277,6 +277,12 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   // the y-axis works counter-intuitively, decreasing as you move up, and increasing as you move down
   // translateToCenter maps coordinates from the HTML canvas to the Scratch-world where (0,0) is in the center of the screen  
   thisContext.translateToCenter = (x, y) => {
+    // If sprite is a polygon, do not translate to center
+    if (thisContext.sprites.length > 0) {
+      if (thisContext.sprites[0].type == "polygon") {
+        return [x, y]
+      }
+    }
     return [(x - (thisContext.width / 2) + thisContext.cameraX) - thisContext._spriteCanvas.offsetLeft, (((thisContext.height / 2) - y) + thisContext.cameraY) + thisContext._spriteCanvas.offsetTop];
   };
   // translateToCanvas (the opposite of translateToCenter) maps coordinates from the Scratch-world to the HTML canvas world with (0,0) in the top-left  
@@ -968,7 +974,7 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   };
   this._onMouseDownHandler = event => {
     var [mouseX, mouseY] = this.project.translateToCenter(event.clientX, event.clientY);
-    if (this.showing && this.over(mouseX, mouseY)){
+    if (this.showing && this.over(mouseX, mouseY)) {
       this._onMouseDowns.forEach((func) => {func(mouseX, mouseY)});
     }
   };

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -563,6 +563,17 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
     thisContext._renderSprites();
   };
   thisContext.ready(thisContext._render);
+  
+  thisContext.collider = () => {
+    return new SAT.Polygon(new SAT.Vector(), [
+    new SAT.Vector(-thisContext.width/2, thisContext.height/2),
+    new SAT.Vector(-thisContext.width/2, -thisContext.height/2),
+    new SAT.Vector(thisContext.width/2, -thisContext.height/2),
+    new SAT.Vector(thisContext.width/2, thisContext.height/2)
+  ]);
+}
+
+  
 };
 
 Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, rotationStyle = "ROTATE", showing = true, penColor = "black", penWidth = 1, penDown = false, showCollider = false, brightness = 100} = {}) {
@@ -842,37 +853,14 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   };
   
   this.overlap = ({left, right, top, bottom}) => {
-    
-    var collider = this.collider();
-    
-    // If collider is a circle, make sure it is inside canvas
-    if (collider.constructor.name == "Circle") {
-      return !(left > collider.pos.x + collider.r || right < collider.pos.x - collider.r || top < collider.pos.y - collider.r || bottom > collider.pos.y + collider.r);
+  
+    if (this.collider().constructor.name == "Circle") {
+      console.log(SAT.testPolygonCircle(this.project.collider(), this.collider(), new SAT.Response()))
+      return SAT.testPolygonCircle(this.project.collider(), this.collider(),  new SAT.Response())
     }
+        console.log(SAT.testPolygonPolygon(this.project.collider(), this.collider(), new SAT.Response()))
+      return SAT.testPolygonPolygon(this.project.collider(), this.collider(), new SAT.Response())
     
-    // Otherwise, collider is a polygon. Find out if it's inside canvas by finding min and max points
-    // Create array for x coordinates of collider polygon
-    var xs = []
-    for (var i = 0; i < collider.calcPoints.length; i++) {
-      xs.push(collider.calcPoints[i].x)
-    }
-    // Create array for y coordinates of collider polygon
-    var ys = []
-    for (var i = 0; i < collider.calcPoints.length; i++) {
-      ys.push(collider.calcPoints[i].y)
-    }
-    // Sort array to find max/min x coordinates
-    var sortedX = xs.sort(function(a,b) {
-      return a - b;
-    })
-    // Sort array to find max/min y coordinates
-    var sortedY = ys.sort(function(a,b) {
-      return a - b;
-    })
-    
-    var maxX = sortedX.length-1;
-    var maxY = sortedY.length-1;
-    return !(left > sortedX[maxX] + collider.pos.x || top < sortedY[0] + collider.pos.y || right < sortedX[0] + collider.pos.x || bottom > sortedY[maxY] + collider.pos.y);
   }
   
   this.over = (x, y) => {

--- a/src/woof.es6.js
+++ b/src/woof.es6.js
@@ -277,12 +277,6 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   // the y-axis works counter-intuitively, decreasing as you move up, and increasing as you move down
   // translateToCenter maps coordinates from the HTML canvas to the Scratch-world where (0,0) is in the center of the screen  
   thisContext.translateToCenter = (x, y) => {
-    // If sprite is a polygon, do not translate to center
-    if (thisContext.sprites.length > 0) {
-      if (thisContext.sprites[0].type == "polygon") {
-        return [x, y]
-      }
-    }
     return [(x - (thisContext.width / 2) + thisContext.cameraX) - thisContext._spriteCanvas.offsetLeft, (((thisContext.height / 2) - y) + thisContext.cameraY) + thisContext._spriteCanvas.offsetTop];
   };
   // translateToCanvas (the opposite of translateToCenter) maps coordinates from the Scratch-world to the HTML canvas world with (0,0) in the top-left  


### PR DESCRIPTION
This fixes the polygons not being clickable bug referenced in #469. It uses the isPointInPath() method, which, instead of defining the shape by top, bottom, right, and left bounds, determines whether the mouse position is a point in the shape's path. The translateToCenter function does not work when this method is used so adjustments for this are made in that function definition. 