### PR TITLE
Smaller bb8 image

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -706,7 +706,7 @@
                             
                             {
                                 url: "./images/boss-ship.png",
-                                code: 'var bossShip2 = new Image({\n  url: "./docs/boss-ship/explosion.png",\n  width: 100, \n  height: 100,\n})',
+                                code: 'var bossShip2 = new Image({\n  url: "./docs/images/boss-ship.png",\n  width: 100, \n  height: 100,\n})',
                                 tags: "ship sprite",
                             },
                             


### PR DESCRIPTION
Addresses issue #528. Shrinks the image for BB8 from about 8mb to about 800kb, which still looks fine to my eyes