### PR TITLE
render error hotfix

### DIFF
--- a/create.html
+++ b/create.html
@@ -1582,9 +1582,12 @@
     }
 
     function runCode() {
-        var iframe = document.getElementById('preview');
+        
+        document.getElementById("preview").remove();
+        var iframe = document.createElement("iframe");
+        iframe.id = "preview";
+        document.getElementById("output").appendChild(iframe);
 
-        iframe.src = ""; // first, we clear the preview iframe
         setTimeout(function() {
 
             // add doctype to iframe


### PR DESCRIPTION
@truthgoddess and I worked on this together to make the following adjustments that we think will remove most instances of a this.render error as described in issue #536 :

1. We changed the runCode call in the refresh button to debouncedRunCode. This takes away the ability for a user to run the code over and over again, reducing call stack errors to basically none.

2. Inside the runCode function, we changed the timeout from 10 to 100 to slow down the number of times tryRunningCode() is called.

3. We removed an extraneous (seemingly) runCode call here: https://github.com/stevekrouse/WoofJS/blob/master/create.html#L1510

In the future, we hope to a) find more efficient ways to run Woof in Woof (runs very well in JSBin for instance) and b) create more friendly error messages if a this.render error does pop up but also for every error.

Ways for you to see if the error is fixed:

Try reproducing the error in two ways on the current version and compare:

1. Press the reload button very quickly over and over again
2. Run your computer on a slower network (a teacher used a 3G connection or something on his Mac and was able to reproduce it)
