### PR TITLE
Fixing Issue with Scheduled Autosave

### DIFF
--- a/create.html
+++ b/create.html
@@ -357,7 +357,7 @@
 
       <img  style= "width:160px; height: 40px;" src="./images/logowhite.png">
       <span style="margin:8px" id="save">
-
+	<span id="autosaveDescription" style="color: white; font-size: smaller;">{{saveMessage}}</span>
         <div class="dropdown" style="display:inline;">
           <button class="btn btn-primary btn-medium dropdown-toggle" type="button" id="toolsDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" style='border:none;'>
             Tools
@@ -709,6 +709,8 @@
         errorMessage: '',
         cursorOnErrorLine: false,
         selectedTheme:'eclipse',
+        saveMessage: '',
+        saveInterval: 0,
         autoSaveStatus: false,
         autoSaveProgress: 0,
         autoSaveEndOfClass: 0, // to keep track of setTimeout that saves at :25 and :55
@@ -1413,12 +1415,36 @@
           app.projectNameRequest = "NOT LOADING"
           saveProjectFirebase({name: name, newProject: true})
         }
+        // since we just saved, reset autosaving logic (besides scheduled end-of-class ones)
+        app.autoSaveProgress = 0;
+        app.autoSaveTimeout = 0;
+        if (app.saveInterval) {
+          clearInterval(app.saveInterval);
+        }
+        if (app.autoSaveStatus) {
+          app.saveMessage = "Autosaved Just Now";
+        } else {
+          app.saveMessage = "Saved Just Now";
+	}		   
+        let saveTime = 0
+	app.saveInterval = setInterval(() => {
+	  saveTime++;
+          if (saveTime == 1) {
+            app.saveMessage = "1 Minute Ago";
+          } else {
+	    app.saveMessage = saveTime + " Minutes Ago";
+	  }
+	  if (app.autoSaveStatus) {
+            app.saveMessage = "Autosaved " + app.saveMessage;
+          } else {
+            app.saveMessage = "Saved " + app.saveMessage;
+	  }
+        }, 60000)
       });
-      // since we just saved, reset autosaving logic (besides scheduled end-of-class ones)
-      app.autoSaveProgress = 0;
-      app.autoSaveTimeout = 0;
       // assume it's not autosaved, though the autosave function will overwrite if appropriate
-      app.autoSaveStatus = false; 
+      // (this needs to go outside of the .then because it needs to happen durring save()
+      // so if this is an autosave, we can overwrite this value to true
+      app.autoSaveStatus = false;
     }
     
     function saveProjectFirebase({name, newProject}) {

--- a/create.html
+++ b/create.html
@@ -331,6 +331,18 @@
       background-color: #f2dede !important;
     }
 
+    .redText {
+      color: red;
+      font-size: small;
+      margin-right: 5px;
+    }
+
+    .whiteText {
+      color: white;
+      font-size: smaller;
+      margin-right: 5px;
+    }
+    
   </style>
 </head>
 <body>
@@ -357,7 +369,7 @@
 
       <img  style= "width:160px; height: 40px;" src="./images/logowhite.png">
       <span style="margin:8px" id="save">
-	<span id="autosaveDescription" style="color: white; font-size: smaller;">{{saveMessage}}</span>
+	<span id="saveDescription" v-bind:class="{ redText: ((status == 'DIRTY') && !getID()), whiteText: ((status != 'DIRTY') || getID())}">{{saveMessage}}</span>
         <div class="dropdown" style="display:inline;">
           <button class="btn btn-primary btn-medium dropdown-toggle" type="button" id="toolsDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" style='border:none;'>
             Tools
@@ -384,7 +396,7 @@
             <li><a @click="share()"><span class="glyphicon glyphicon-share-alt"></span> Share</a></li>
           </ul>
         </div>
-        <button style="display: none" :style="{display: 'inline-block'}" style="margin-right: 5px; background-color:#4390BF !important; ; border:none; color:white; " class="btn btn-medium" :class="styles" onclick="save()">{{ status == "SAVED" ? (autoSaveStatus ? 'Autosaved' : 'Saved') : 'Save' }}</button> 
+        <button style="display: none" :style="{display: 'inline-block'}" style="margin-right: 5px; background-color:#4390BF !important; ; border:none; color:white; " class="btn btn-medium" :class="styles" onclick="save()">{{ status == "SAVED" ? (autoSaveStatus ? 'Autosaved' : 'Saved') : "Save" }}</button> 
       </span>
     </div>
 
@@ -755,7 +767,7 @@
            // styles for the "Save" button
           'btn-warning': this.status == 'DIRTY',
           'btn-success': this.status == 'SAVED',
-          'btn-default': this.status == "NEW"
+          'btn-default': this.status == 'NEW',
         } },
         canClean: function(){
           return !this.error 
@@ -1615,6 +1627,9 @@
     // run the code (debounced) on every change to the editor 
     editor.on("change", function(){
       makeDirty()
+      if (!getID()) {
+        app.saveMessage = "Never Saved"
+      }
       if (app.autoSaveChecked) {
         debouncedAutoSave()
         if (!app.autoSaveEndOfClass) {


### PR DESCRIPTION
In #597 the scheduled autosaves (that occur at :25 and :55 of each hour) did not require the user to be logged in (or a project to exist) to initiate a save. This can result in projects being saved (using up project name-space and server resources) while not being associated with a username, which is not good. I'm not exactly sure what assumptions on the FireBase end this breaks, but I suspect it breaks some of them.

This pull request makes it so we don't schedule autosaves unless the user is logged in. A user that is logged in and working on a never-saved project will still have autosaves prompt them to save (by giving the project a name) at :25 and :55 (autosaving based on time dirty and number of changes won't trigger if the project is unnamed because I think it's too annoying to have pop-ups asking you to save with the same frequency that makes sense for autosaving).