### PR TITLE
Update codemirror links to point at more permanent css files

### DIFF
--- a/create.html
+++ b/create.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html style="height:100%">
 <head>
@@ -62,20 +63,20 @@
   <script src="./vendor/codemirror/lint.js"></script>
   <script src="./vendor/levenshtein.js"></script>
   <script src="./vendor/codemirror/scrollpastend.js"></script>
-  <link rel="stylesheet" href="https://codemirror.net/theme/3024-day.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/3024-night.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/ambiance.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/base16-dark.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/base16-light.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/blackboard.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/cobalt.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/eclipse.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/elegant.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/erlang-dark.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/lesser-dark.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/midnight.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/monokai.css">
-  <link rel="stylesheet" href="https://codemirror.net/theme/neat.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/3024-day.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/3024-night.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/ambiance.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/base16-dark.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/base16-light.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/blackboard.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/cobalt.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/eclipse.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/elegant.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/erlang-dark.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/lesser-dark.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/midnight.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/monokai.css">
+  <link rel="stylesheet" href="https://codemirror.net/5/theme/neat.css">
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
   <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
   <script src="https://rawcdn.githack.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>


### PR DESCRIPTION
As codemirror updated to Version 6, their links to old css files broke. This is updating them.