### PR TITLE
Text Sprite Updates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -437,11 +437,21 @@
 
                         ],
                         Text: [ 
-                        {
-                           description: "Create new text:",
-                           code: 'var textSprite1 = new Text()\ntextSprite1.text = () => "Hello World!"\ntextSprite1.size = 12\ntextSprite1.color = "rgb(100, 50, 240)"',
-                           tags: 'create make new text words string'
+                         {
+                             description: "Create new text:",
+                             code: 'var textSprite1 = new Text()\ntextSprite1.text = () => "Hello World!"\ntextSprite1.size = 12\ntextSprite1.color = "rgb(100, 50, 240)"',
+                             tags: 'create make new text words string'
                          },
+	                 {
+	                     description: "Set text:",
+	                     code: "textSprite1.text = () => variable1",
+	                     tags: "text words string"
+	                 },
+	                 {
+	                     description: "You can use \\n to make multiple lines of text:",
+	                     code: 'textSprite1.text = () => "First line\\nSecond Line"',
+	                     tags: "text words string multiple lines"
+	                 },
                          {
                              description: "Set location:",
                              code: "textSprite1.x = 50\ntextSprite1.y = -100",

--- a/woof.js
+++ b/woof.js
@@ -689,6 +689,12 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
   this.toJSON = () => {
     return {x: this.x, y: this.y, angle: this.angle, rotationStyle: this.rotationStyle, showing: this.showing, penDown: this._penDown, penColor: this.penColor, penWidth: this.penWidth, deleted: this.deleted};
   };
+
+  // this is deliberately simple to make it so showing sprites via
+  //   text is somewhat informative and not overwhelming
+  this.toString = () => {
+    return this.type + "@(" + this.x + "," + this.y + ")";
+  }
   
   [this.lastX, this.lastY] = [this.x, this.y];
   this.trackPen = () => {

--- a/woof.js
+++ b/woof.js
@@ -115,7 +115,7 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
       }
     }
   });
-  
+
   if (thisContext.fullScreen1) {
     width = window.innerWidth;
     height = window.innerHeight;
@@ -616,7 +616,7 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
     thisContext._render = () => {
     thisContext._runRepeats(); // we need to run the repeats even if stopped because the defrost() code likely lives in a repeat
     thisContext._calculateMouseSpeed();
-    thisContext.renderInterval = window.requestAnimationFrame(thisContext._render); // WARNING this line makes render recursive. Only call is once and it will continue to call itself ~30fps.
+    thisContext.renderInterval = window.requestAnimationFrame(thisContext._render); // WARNING this line makes render recursive. Only call is once and it will continue to call itself ~60fps.
     if (thisContext.stopped) { return; }
     thisContext._renderSprites();
   };
@@ -631,8 +631,15 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   ]);
 }
 
-  
 };
+
+// make the toString more explicitly a list
+//   (especially helpful for 0 or 1 element lists)
+// I'm not confident where this toString definition "should" go,
+//   it also works fine inside the Woof function (in the above curly bracket)
+Array.prototype.toString = function() {
+  return '[' + this.join(',') + ']'
+}
 
 Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, rotationStyle = "ROTATE", showing = true, penColor = "black", penWidth = 1, penDown = false, showCollider = false, brightness = 100} = {}) {
   if (!project) {

--- a/woof.js
+++ b/woof.js
@@ -752,19 +752,27 @@ Woof.prototype.Sprite = function({project = undefined, x = 0, y = 0, angle = 0, 
     }
     // Otherwise, create 4-sided collider around sprite
     else {
+      var textXOffset = 0
+      if (this.type == "text") {
+	if (this.textAlign == "start" || this.textAlign == "left") {
+	  textXOffset = this.width / 2
+	} else if (this.textAlign == "end" || this.textAlign == "right") {
+	  textXOffset = - this.width / 2
+	}
+      }
       if (this.rotationStyle == "ROTATE") {
-        var pos = this.rotatedVector(this.x - this.width / 2, this.y - this.height / 2)
+        var pos = this.rotatedVector(this.x - this.width / 2 + textXOffset, this.y - this.height / 2)
         var v1 = new SAT.Vector(0, 0)
-        var v2 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y - this.height / 2))
-        var v3 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2, this.y + this.height / 2))
-        var v4 = this.translatedVector(pos, this.rotatedVector(this.x - this.width / 2, this.y + this.height / 2))
+        var v2 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2 + textXOffset, this.y - this.height / 2))
+        var v3 = this.translatedVector(pos, this.rotatedVector(this.x + this.width / 2 + textXOffset, this.y + this.height / 2))
+        var v4 = this.translatedVector(pos, this.rotatedVector(this.x - this.width / 2 + textXOffset, this.y + this.height / 2))
 	      return new SAT.Polygon(pos, [v1, v2, v3, v4])
       } else { // rotation style is LEFT RIGHT or NO ROTATE, which should have non-rotated collider
-      	var pos = new SAT.Vector(this.x - this.width/2, this.y - this.height/2)
+      	var pos = new SAT.Vector(this.x - this.width/2 + textXOffset, this.y - this.height/2)
       	var v1 = new SAT.Vector(0,0)
-      	var v2 = this.translatedVector(pos, new SAT.Vector(this.x + this.width / 2, this.y - this.height / 2))
-        var v3 = this.translatedVector(pos, new SAT.Vector(this.x + this.width / 2, this.y + this.height / 2))
-        var v4 = this.translatedVector(pos, new SAT.Vector(this.x - this.width / 2, this.y + this.height / 2))
+      	var v2 = this.translatedVector(pos, new SAT.Vector(this.x + this.width / 2 + textXOffset, this.y - this.height / 2))
+        var v3 = this.translatedVector(pos, new SAT.Vector(this.x + this.width / 2 + textXOffset, this.y + this.height / 2))
+        var v4 = this.translatedVector(pos, new SAT.Vector(this.x - this.width / 2 + textXOffset, this.y + this.height / 2))
 	      return new SAT.Polygon(pos, [v1, v2, v3, v4])
       }
     }
@@ -1077,8 +1085,6 @@ Woof.prototype.Text = function({project = undefined, text = "Text", size = 12, c
   this.size = Math.abs(size);
   this.color = color;
   this.fontFamily = fontFamily;
-  // TODO remove text align or make the collider take it into account
-  // currently, the collider doesn't know about textAlign so things can be quite inaccurate
   this.textAlign = textAlign;
   
   Object.defineProperty(this, 'width', {


### PR DESCRIPTION
Multiline Text Support, which involved a bit of a refactor:
- A new type of sprite called a Bundle. I considered exposing this to students in the documentation, but seems fairly persnickety for not a huge benefit, leaving it in the background for now. A super basic demo of bundles is [here](https://hallpell.github.io/create.html#hallpell_bundle-demo). Movement, rotation, mouseUp/Down/Over, touching, and deleting should all work. The main thing that doesn't work is size based stuff (width and height are not defined for generic Bundles), which could exist later but isn't worth the effort at the moment.
- Old Text Sprites are now called TextPrimative, and no longer can receive functions (that will evaluate to text) as their text field. (and shouldn't be used by students)
- As of now, Text Sprites are Bundles (in the subclass sense), and dynamically create (and destroy) TextPrimatives as the number of lines change (based on searching for `\n`s. If projects relied on `sprite.type == "text"` before, that will be broken, but I don't think any did (it's not exposed in the documentation).

And other assorted updates:
- Text Sprites now properly update colliders based on their textAlign property.
- Sprites toString method is updated to be "type(x,y)"
- Arrays toString method is updated to have square brackets to more clearly indicate arrays