### PR TITLE
Make Text Sprite Update Quicker

### DIFF
--- a/woof.js
+++ b/woof.js
@@ -2164,6 +2164,9 @@ Woof.prototype.keyCodeToString = function(keyCode) {
   else if (keyCode == 220){
     return "\\";
   }
+  else if (keyCode == 221){
+    return "]"
+  }
   else if (keyCode == 191){
     return "/";
   }


### PR DESCRIPTION
Many of the effects of updating text sprites (text, fontFamily, and size) wouldn't impact the underlying TextPrimatives until after it ran `_render`, which was slightly problematic (I tried to set text and then measure width, which wasn't working and the impetus for this change).

This also implies some issues with Bundles. If we update offsetX, offsetY, or offsetAngle of a component sprite in a Bundle, it won't take effect until we run a _render (at the end of a forever loop).