### PR TITLE
Assorted Text/Bundle Fixes

### DIFF
--- a/woof.js
+++ b/woof.js
@@ -1381,9 +1381,6 @@ Woof.prototype.Text = function({project = undefined, text = "Text", size = 12, c
       return this.privateText;
     },
     set: function(value) {
-      if (!(typeof value == 'function' || typeof value == 'string')) {
-	throw new TypeError("Text.text must be set to a function or a string, given: " + value);
-      }
       this.privateText = value;
       this._render();
     }
@@ -1508,6 +1505,9 @@ Woof.prototype.Text = function({project = undefined, text = "Text", size = 12, c
   //   TextPrimatives in components. That should generally be
   //   true but is not a super strong assumption
   this._render = function(context) {
+    if (!this.project || this.project.stopped) {
+      return;
+    }
     let textList = this.textEval().split("\n")
     // make the component text sprites equal the number of lines
     while (textList.length < this.components.length) {


### PR DESCRIPTION
Main fixes:
1) Event Handlers were building up, as the handlers added in the call to the super-class of Sprite were inaccessible and unable to be removed when sprites were deleted. We now remove those event handlers when a bundle is created, since the bundle gets its own event handlers.
2) I ran into issues where text sprites were being created before the '#project' (and thus the sprite canvas) were initialized. When the _render code ran, it would break and stop the rest of the user's code from running. This may have only been an issue on my local computer, (it didn't seem to be broken on the live site...) but seems generally beneficial to fix it.
3) Opacity/brightness was not being propagated down to components in bundles.