### PR TITLE
Infinite Loop Busting and Updating Babel target

### DIFF
--- a/create.html
+++ b/create.html
@@ -775,11 +775,12 @@
           this.suggestions = []
           this.errorMessage = []
           this.renameSprite = false
+          let lineNum = -1; // for extracting line number from messages (initially added for loop busting)
           // Remove error line highlight
           if (this.errorLineNumber) {
             editor.removeLineClass(this.errorLineNumber - 1, 'text', 'error-highlight');
           }
-          if (this.error.message.includes("Uncaught ReferenceError") || this.error.message.includes("Uncaught TypeError")) {
+            if (this.error.message.includes("Uncaught ReferenceError") || (this.error.message.includes("Uncaught TypeError") && (!this.error.message.includes('A loop ran for too long')))) {
             // Remove 'Uncaught..' from error message
             this.errorMessage = this.error.message.split(" ").slice(2).join(" ");
             // If error message is 'VAR not defined', ask user to rename VAR
@@ -804,7 +805,14 @@
               }
             }
           }
-	  else {
+	  else if (this.error.message.includes('A loop ran for too long')) {
+	    var errorDesc = this.error.message.split("\n");
+	    if (errorDesc[0].includes("Uncaught TypeError:")) {
+	      errorDesc[0] = errorDesc[0].substr(20)
+	      lineNum = parseInt(errorDesc[1])
+	    }
+	    this.errorMessage = errorDesc[0];
+	  } else {
             // Split error message by line break
 	    var errorDesc = this.error.message.split("\n");
             // Display first line of error message
@@ -818,11 +826,14 @@
             }
           }
           // Show error line number if it is accurate
-          if (this.error.lineno <= editor.lineCount()) {
+          if (this.error.lineno <= editor.lineCount() && lineNum == -1) {
             this.errorLineNumber = this.error.lineno;
             // Add highlight to error line
             editor.addLineClass(this.errorLineNumber - 1, 'text', 'error-highlight');
-          } else {
+	  } else if (lineNum != -1) {
+	    this.errorLineNumber = lineNum;
+	    editor.addLineClass(this.errorLineNumber - 1, 'text', 'error-highlight');
+	  } else {
             this.errorLineNumber = undefined
           }
         },

--- a/create.html
+++ b/create.html
@@ -73,8 +73,7 @@
   <link rel="stylesheet" href="./vendor/codemirror/midnight.css">
   <link rel="stylesheet" href="./vendor/codemirror/monokai.css">
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
-  <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
-  <script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.21.4/babel.min.js"></script>
   <script src="https://rawcdn.githack.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>
   <style>
 

--- a/create.html
+++ b/create.html
@@ -74,6 +74,7 @@
   <link rel="stylesheet" href="./vendor/codemirror/monokai.css">
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
   <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
+  <script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
   <script src="https://rawcdn.githack.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>
   <style>
 
@@ -803,7 +804,7 @@
               }
             }
           }
-          else {
+	  else {
             // Split error message by line break
 	    var errorDesc = this.error.message.split("\n");
             // Display first line of error message
@@ -1734,7 +1735,8 @@
 		app.error = event
             }
             app.processError()
-            CodeMirror.commands.markGutter(editor, "error", app.error.lineno, app.error.message)
+	    CodeMirror.commands.markGutter(editor, "error", app.error.lineno, app.error.message)
+	    event.preventDefault();
         });
 
 	// run the user code in the iframe document

--- a/docs/index.html
+++ b/docs/index.html
@@ -1382,14 +1382,13 @@
                         tags: "repeat times control for index"
                     }, {
                         html: "When you use <code>repeat()</code>, your code doesn't repeat as fast as the computer can run it.\
-                        Instead, we slow it down, which makes things like animation and motion work well. But, if you want your code to repeat instantly,\
-                        as fast as the computer can do it, you can combine the <code>range()</code> function with the <code>forEach()</code> function:\
-                        <br><br>Example: Repeat your code instantly 10 times, starting <code>counter</code> at 0 and going up by one each repetition, stopping before it gets to 10:",
+                               It runs slower, which makes things like animation and motion work well.\
+	                       <br><br>If you want your code to repeat as fast as the computer can do it,\
+			       you can combine the <code>range()</code> function with the <code>forEach()</code> function:",
                         code: "range(0, 10).forEach(counter => {\n  \/* something to repeat */\n})",
                         tags: "repeat range array forEach control for index"
                     }, {
-                        html: "If you are familiar with <code>for</code> loops, you might realize that this does the same thing.\
-                        We recommend using <code>range().forEach()</code> instead of <code>for</code>."
+	                html: "If you want more control when repeating quickly, you can look up how to use <code>for</code> or <code>while</code> loops."
                     }, {
                         url: "./images/68747470733a2f2f692e696d6775722e636f6d2f675a4f6a4c444d2e706e67",
                         code: 'forever(() => {\n  \/* do stuff here */\n})',

--- a/full.html
+++ b/full.html
@@ -3,6 +3,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
 <script data-presets="es2017" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
+<script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
 <script type="text/javascript" src="./run-code.js"></script>
 <script>
 

--- a/full.html
+++ b/full.html
@@ -3,7 +3,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
 <script data-presets="es2017" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
-<script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.21.4/babel.min.js"></script>
 <script type="text/javascript" src="./run-code.js"></script>
 <script>
 

--- a/team-full.html
+++ b/team-full.html
@@ -3,8 +3,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
 <script src="https://cdn.firebase.com/libs/firepad/1.4.0/firepad.min.js"></script>
-<script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
-<script data-presets="es2017" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.21.4/babel.min.js"></script>
 <script type="text/javascript" src="./run-code.js"></script>
 <script>
 

--- a/team-full.html
+++ b/team-full.html
@@ -3,6 +3,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
 <script src="https://cdn.firebase.com/libs/firepad/1.4.0/firepad.min.js"></script>
+<script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
 <script data-presets="es2017" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
 <script type="text/javascript" src="./run-code.js"></script>
 <script>

--- a/team.html
+++ b/team.html
@@ -60,6 +60,7 @@
   <script src="./vendor/codemirror/lint.js"></script>
   <script src="./vendor/codemirror/scrollpastend.js"></script>
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
+  <script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
   <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
   <script src="https://rawcdn.githack.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>
  

--- a/team.html
+++ b/team.html
@@ -60,8 +60,7 @@
   <script src="./vendor/codemirror/lint.js"></script>
   <script src="./vendor/codemirror/scrollpastend.js"></script>
   <script src="https://unpkg.com/vue@2.0.1/dist/vue.js"></script>
-  <script src="https://unpkg.com/esprima@~3.1/dist/esprima.js"></script>
-  <script data-presets="es2015" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.21.4/babel.min.js"></script>
   <script src="https://rawcdn.githack.com/beautify-web/js-beautify/1b52eb1f90daaefa6ff0fa7736f97fbfc58093c1/js/lib/beautify.js"></script>
  
    <!-- Firepad -->

--- a/woof.js
+++ b/woof.js
@@ -602,7 +602,7 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
   thisContext._shouldThrowError = (ind, lineNo) => {
     var shouldStop = thisContext._shouldStopLoop(ind);
     if (shouldStop) {
-      throw new TypeError("A loop ran for too long", "woof.js", lineNo)
+	throw new TypeError("A loop ran for too long\n" + lineNo)
     }
     return shouldStop;
   }


### PR DESCRIPTION
Updating Babel, partially to no longer target ES2015 (and let it try to figure out a reasonable target based on information it gathers from the browser) and partially so we can parse + insert Infinite Loop Busting code.

The loop busting code resolves #437 .

This means that we don't need to be as afraid of for and while loops - if a student accidentally writes an infinite loop, the loop will break with an error after ~4 seconds. Previously this would cause the page to hang and prevent saving of work, which was very frustrating. It should now be more reasonable. I mention for and while loops in the documentation, but don't have examples of them (I think we should still recommend students use range(0,n).forEach(()=>{}) as opposed to a for loop, but want it be more usable for the advanced students that explore them anyway)
There are two parameters controlling this, which are accessible in any Woof script. _START_MONITORING_LOOPS  and  _MAX_LOOP_TIME are variables (representing time in milliseconds) that both default to 2000 (i.e. 2 seconds) and can be changed if needed.
_START_MONITORING_LOOPS gives grace period at the beginning of a Woof script running before we start monitoring loops.
_MAX_LOOP_TIME indicates how long a loop can run without being broken out of. Each frame rendered will reset this timer for every loop.