### PR TITLE
Fix Clean Code

### DIFF
--- a/create.html
+++ b/create.html
@@ -382,8 +382,8 @@
             <li><a @click="find()"><span class="fa fa-search"></span> Find <span><kbd>{{shortcut}}</kbd>+<kbd>F</kbd></span></a></li>
             <li><a @click="replace()"><span class="fa fa-search-plus"></span> Replace <span><kbd>{{shortcut}}</kbd>+<kbd>H</kbd></span></a></li>
             <li role="separator" class="divider"></li>
-            <li><a @click="cleanAll()" :style="{display: canClean ? 'block' : 'none'}"><span class="glyphicon glyphicon-align-left"></span> Clean Code <span><kbd>{{shortcut}}</kbd>+<kbd>B</kbd></span></a></li>
-            <li class='disabled'><a @click="cleanAll()"  :style="{display: canClean ? 'none' : 'block'}" data-toggle="popover" data-trigger="hover" data-content="You can't clean when there's an error." data-placement="top"><span class="glyphicon glyphicon-align-left"></span> Clean Code <span><kbd>{{shortcut}}</kbd>+<kbd>B</kbd></span></a></li>
+            <li><a @click="cleanCode()" :style="{display: canClean ? 'block' : 'none'}"><span class="glyphicon glyphicon-align-left"></span> Clean Code <span><kbd>{{shortcut}}</kbd>+<kbd>B</kbd></span></a></li>
+            <li class='disabled'><a @click="cleanCode()"  :style="{display: canClean ? 'none' : 'block'}" data-toggle="popover" data-trigger="hover" data-content="You can't clean when there's an error." data-placement="top"><span class="glyphicon glyphicon-align-left"></span> Clean Code <span><kbd>{{shortcut}}</kbd>+<kbd>B</kbd></span></a></li>
             <li><a @click="comment()"><span class="fa fa-code"></span> Comment Code <span><kbd>{{shortcut}}</kbd>+<kbd>/</kbd></span></a></li>
             <li role="separator" class="divider"></li>
             <li><a><input onclick="autoRunClicked()" type="checkbox" id="checkbox" v-model="autoRunChecked"></span> Auto Run</a></li>
@@ -856,11 +856,14 @@
         goToErrorLine: function() {
           editor.scrollIntoView({line: this.errorLineNumber, ch:0}, editor.getScrollInfo().clientHeight / 2);
         },
-        cleanAll: function(){
-          if (!this.error && this.code != js_beautify(this.code, {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })){
-            var beautiful = js_beautify(editor.getValue(), {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })
-            editor.setValue(beautiful)
-          }
+        cleanCode: function(){
+	  if (!this.error) {
+	    if (editor.getSelection() == ""){
+	      editor.execCommand("selectAll");
+	    }
+	    var beautiful = js_beautify(editor.getSelection(), {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })
+	    editor.replaceSelection(beautiful)
+	  }
         },
         share: function(){
           $('#shareModal').modal('show')
@@ -1539,11 +1542,7 @@
     var ctrl = mac ? "Cmd-" : "Ctrl-";
     var keymap = {}
     keymap[ctrl + "B"] = function(cm) {
-       if (cm.getSelection() == ""){
-        cm.execCommand("selectAll");
-       }
-      var beautiful = js_beautify(cm.getSelection(), {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })
-      cm.replaceSelection(beautiful)
+      app.cleanCode()
     }
     keymap.Tab = function(cm) {
       if (cm.somethingSelected()) {

--- a/create.html
+++ b/create.html
@@ -779,7 +779,7 @@
           if (this.errorLineNumber) {
             editor.removeLineClass(this.errorLineNumber - 1, 'text', 'error-highlight');
           }
-            if (this.error.message.includes("Uncaught ReferenceError") || (this.error.message.includes("Uncaught TypeError") && (!this.error.message.includes('A loop ran for too long')))) {
+          if (this.error.message.includes("Uncaught ReferenceError") || (this.error.message.includes("Uncaught TypeError") && (!this.error.message.includes('A loop ran for too long')))) {
             // Remove 'Uncaught..' from error message
             this.errorMessage = this.error.message.split(" ").slice(2).join(" ");
             // If error message is 'VAR not defined', ask user to rename VAR

--- a/team.html
+++ b/team.html
@@ -418,6 +418,7 @@
           }
         },
         cleanAll: function(){
+	  // this is not called currently, but left in just in case
           var beautiful = js_beautify(editor.getValue(), {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })
           editor.setValue(beautiful)
         },
@@ -594,6 +595,9 @@
     var ctrl = mac ? "Cmd-" : "Ctrl-";
     var keymap = {}
     keymap[ctrl + "B"] = function(cm) {
+      if (cm.getSelection() == "") {
+        cm.execCommand("selectAll")
+      }
       var beautiful = js_beautify(cm.getSelection(), {space_after_anon_function: true, indent_size: 2, indent_with_tabs: false })
       cm.replaceSelection(beautiful)
     }

--- a/woof.js
+++ b/woof.js
@@ -635,29 +635,29 @@ function Woof({global = false, fullScreen = false, height = 500, width = 350} = 
     [thisContext.pMouseX, thisContext.pMouseY] = [thisContext.mouseX, thisContext.mouseY];
   };
 
-   // The timer begins when Woof is loaded
-   thisContext.woofEpoch = new Date();
-   thisContext.timer = function(){
-        if (arguments.length > 0) { throw new TypeError("timer() requires no inputs."  ); }
-        let date = new Date();
-        return ( date - thisContext.woofEpoch ) / 1000;
-    };
-    thisContext.resetTimer = function(){
-        if (arguments.length > 0) { throw new TypeError("resetTimer() requires no inputs."); }
-        thisContext.woofEpoch = new Date();
-    };
+  // The timer begins when Woof is loaded
+  thisContext.woofEpoch = new Date();
+  thisContext.timer = function(){
+    if (arguments.length > 0) { throw new TypeError("timer() requires no inputs."  ); }
+    let date = new Date();
+    return ( date - thisContext.woofEpoch ) / 1000;
+  };
+  thisContext.resetTimer = function(){
+    if (arguments.length > 0) { throw new TypeError("resetTimer() requires no inputs."); }
+    thisContext.woofEpoch = new Date();
+  };
 
-    thisContext._render = () => {
-      // reset "fast" loop timers (we only have an issue if they take too long within one frame)
-      thisContext._loopTimers = {}
-      // we need to run the repeats even if stopped because the defrost() code likely lives in a repeat
-      thisContext._runRepeats();
-      thisContext._calculateMouseSpeed();
-      thisContext.renderInterval = window.requestAnimationFrame(thisContext._render); // WARNING this line makes render recursive. Only call is once and it will continue to call itself ~60fps.
-      if (thisContext.stopped) { return; }
-      thisContext._renderSprites();
-    };
-    thisContext.ready(thisContext._render);
+  thisContext._render = () => {
+    // reset "fast" loop timers (we only have an issue if they take too long within one frame)
+    thisContext._loopTimers = {}
+    // we need to run the repeats even if stopped because the defrost() code likely lives in a repeat
+    thisContext._runRepeats();
+    thisContext._calculateMouseSpeed();
+    thisContext.renderInterval = window.requestAnimationFrame(thisContext._render); // WARNING this line makes render recursive. Only call is once and it will continue to call itself ~60fps.
+    if (thisContext.stopped) { return; }
+    thisContext._renderSprites();
+  };
+  thisContext.ready(thisContext._render);
   
   thisContext.collider = () => {
     return new SAT.Polygon(new SAT.Vector(), [


### PR DESCRIPTION
Clean Code from the dropdown menu wasn't working properly in create.html, so updated (and refactored so both Ctrl+B and Clean Code from the dropdown share code).

Relatedly, in team.html Ctrl+B would only format the selected code (as opposed to all of it), which is now updated. There's a chance this is an issue for team projects (if two people are simultaneously working on different parts and someone formats the whole file, the other person might lose their place/get confused), but I think it's more important for Ctrl+B to work by default.